### PR TITLE
RC for v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ USAGE
 <!-- usagestop -->
 
 After install run `ssmenv init` to generate configuration files for the
-project.  The configuration files are places in the `.ssmenv` directory as
+project.  The configuration files are placed in the `.ssmenv` directory as
 `public.json` and `private.json`. `public.json` will only contain data that is
 not sensitive, it should be added to source control. `private.json` will
 contain sensitive data (such as AWS access key credentials) and should be

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install -g ssmenv
 $ ssmenv COMMAND
 running command...
 $ ssmenv (-v|--version|version)
-ssmenv/0.1.3 darwin-x64 node-v9.10.1
+ssmenv/0.2.0 darwin-x64 node-v9.11.1
 $ ssmenv --help [COMMAND]
 USAGE
   $ ssmenv COMMAND
@@ -45,6 +45,7 @@ for input.
 * [ssmenv init [ROOTPATH] [AWSACCESS] [AWSSECRET]](#ssmenv-init-rootpath-awsaccess-awssecret)
 * [ssmenv var STAGE KEY VALUE](#ssmenv-var-stage-key-value)
 * [ssmenv var:set STAGE KEY VALUE](#ssmenv-varset-stage-key-value)
+* [ssmenv var:tag STAGE KEY](#ssmenv-vartag-stage-key)
 
 ## ssmenv env STAGE
 
@@ -70,7 +71,7 @@ EXAMPLES
   $ ssmenv env:dotenv test > .env.test
 ```
 
-_See code: [src/commands/env.ts](https://github.com/oursiberia/ssmenv/blob/v0.1.3/src/commands/env.ts)_
+_See code: [src/commands/env.ts](https://github.com/oursiberia/ssmenv/blob/v0.2.0/src/commands/env.ts)_
 
 ### ssmenv env:dotenv STAGE
 
@@ -96,7 +97,7 @@ EXAMPLES
   $ ssmenv env:dotenv test > .env.test
 ```
 
-_See code: [src/commands/env/dotenv.ts](https://github.com/oursiberia/ssmenv/blob/v0.1.3/src/commands/env/dotenv.ts)_
+_See code: [src/commands/env/dotenv.ts](https://github.com/oursiberia/ssmenv/blob/v0.2.0/src/commands/env/dotenv.ts)_
 
 ## ssmenv env:dotenv STAGE
 
@@ -122,7 +123,7 @@ EXAMPLES
   $ ssmenv env:dotenv test > .env.test
 ```
 
-_See code: [src/commands/env/dotenv.ts](https://github.com/oursiberia/ssmenv/blob/v0.1.3/src/commands/env/dotenv.ts)_
+_See code: [src/commands/env/dotenv.ts](https://github.com/oursiberia/ssmenv/blob/v0.2.0/src/commands/env/dotenv.ts)_
 
 ## ssmenv help [COMMAND]
 
@@ -172,7 +173,7 @@ EXAMPLES
   * Recommend ignoring .ssmenv/private.json in source control.
 ```
 
-_See code: [src/commands/init.ts](https://github.com/oursiberia/ssmenv/blob/v0.1.3/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/oursiberia/ssmenv/blob/v0.2.0/src/commands/init.ts)_
 
 ## ssmenv var STAGE KEY VALUE
 
@@ -188,9 +189,7 @@ ARGUMENTS
   VALUE  Value of the variable to set.
 
 OPTIONS
-  -d, --description=description     Description of the variable.
-  -k, --withEncryption=KMS Key ARN  Attempt to encrypt parameter using KMS key name.
-  -t, --tag=TagName:TagValue        Tags to set on the variable as TagName:TagValue.
+  -d, --description=description  Description of the variable.
 
 EXAMPLES
   # Set value of FOO variable in test stage.
@@ -213,7 +212,7 @@ EXAMPLES
   }
 ```
 
-_See code: [src/commands/var.ts](https://github.com/oursiberia/ssmenv/blob/v0.1.3/src/commands/var.ts)_
+_See code: [src/commands/var.ts](https://github.com/oursiberia/ssmenv/blob/v0.2.0/src/commands/var.ts)_
 
 ### ssmenv var:set STAGE KEY VALUE
 
@@ -229,9 +228,7 @@ ARGUMENTS
   VALUE  Value of the variable to set.
 
 OPTIONS
-  -d, --description=description     Description of the variable.
-  -k, --withEncryption=KMS Key ARN  Attempt to encrypt parameter using KMS key name.
-  -t, --tag=TagName:TagValue        Tags to set on the variable as TagName:TagValue.
+  -d, --description=description  Description of the variable.
 
 EXAMPLES
   # Set value of FOO variable in test stage.
@@ -254,7 +251,32 @@ EXAMPLES
   }
 ```
 
-_See code: [src/commands/var/set.ts](https://github.com/oursiberia/ssmenv/blob/v0.1.3/src/commands/var/set.ts)_
+_See code: [src/commands/var/set.ts](https://github.com/oursiberia/ssmenv/blob/v0.2.0/src/commands/var/set.ts)_
+
+### ssmenv var:tag STAGE KEY
+
+Add tags to a variable. Variable must exist.
+
+```
+USAGE
+  $ ssmenv var:tag STAGE KEY
+
+ARGUMENTS
+  STAGE  Stage to use for retrieving data. Appended to root path.
+  KEY    Key to use when setting the variable; AKA variable name.
+
+OPTIONS
+  -t, --tag=TagName:TagValue  Tags to set on the variable as TagName:TagValue.
+
+EXAMPLES
+  # Set Client tag of FOO variable in test stage.
+  $ ssmenv var:set test FOO --tag=Client:baz
+
+  # Set multiple tags on FOO variable for staging.
+  $ ssmenv var:set staging FOO --tag=Client:baz --tag=Environment:staging
+```
+
+_See code: [src/commands/var/tag.ts](https://github.com/oursiberia/ssmenv/blob/v0.2.0/src/commands/var/tag.ts)_
 
 ## ssmenv var:set STAGE KEY VALUE
 
@@ -270,9 +292,7 @@ ARGUMENTS
   VALUE  Value of the variable to set.
 
 OPTIONS
-  -d, --description=description     Description of the variable.
-  -k, --withEncryption=KMS Key ARN  Attempt to encrypt parameter using KMS key name.
-  -t, --tag=TagName:TagValue        Tags to set on the variable as TagName:TagValue.
+  -d, --description=description  Description of the variable.
 
 EXAMPLES
   # Set value of FOO variable in test stage.
@@ -295,5 +315,30 @@ EXAMPLES
   }
 ```
 
-_See code: [src/commands/var/set.ts](https://github.com/oursiberia/ssmenv/blob/v0.1.3/src/commands/var/set.ts)_
+_See code: [src/commands/var/set.ts](https://github.com/oursiberia/ssmenv/blob/v0.2.0/src/commands/var/set.ts)_
+
+## ssmenv var:tag STAGE KEY
+
+Add tags to a variable. Variable must exist.
+
+```
+USAGE
+  $ ssmenv var:tag STAGE KEY
+
+ARGUMENTS
+  STAGE  Stage to use for retrieving data. Appended to root path.
+  KEY    Key to use when setting the variable; AKA variable name.
+
+OPTIONS
+  -t, --tag=TagName:TagValue  Tags to set on the variable as TagName:TagValue.
+
+EXAMPLES
+  # Set Client tag of FOO variable in test stage.
+  $ ssmenv var:set test FOO --tag=Client:baz
+
+  # Set multiple tags on FOO variable for staging.
+  $ ssmenv var:set staging FOO --tag=Client:baz --tag=Environment:staging
+```
+
+_See code: [src/commands/var/tag.ts](https://github.com/oursiberia/ssmenv/blob/v0.2.0/src/commands/var/tag.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssmenv",
   "description": "Manage environment variables with AWS SSM.",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "author": "Bryan Swift",
   "bin": {
     "ssmenv": "./bin/run"

--- a/src/commands/env/dotenv.ts
+++ b/src/commands/env/dotenv.ts
@@ -47,6 +47,6 @@ export class EnvDotenv extends Command {
     }
     config.variables
       .map(envVar => `${envVar.key.toUpperCase()}=${envVar.value}`)
-      .forEach(this.log.bind(this));
+      .forEach(line => this.log(line));
   }
 }

--- a/src/commands/var/set.ts
+++ b/src/commands/var/set.ts
@@ -5,12 +5,12 @@ import { Key, keyPositional } from '../../arguments/key';
 import { Stage, stagePositional } from '../../arguments/stage';
 import { Value, valuePositional } from '../../arguments/value';
 import { make as makeExample } from '../../example';
+import { descriptionFlag, WithDescriptionFlag } from '../../flags/description';
+import { tagFlag, WithTagFlag } from '../../flags/tag';
 import { getEnvironment } from '../../projectConfig';
 import { parseTag, Tag, validateTag } from '../../tag';
 
-interface Flags {
-  tag: string[];
-  description?: string;
+interface Flags extends WithDescriptionFlag, WithTagFlag {
   withEncryption?: string;
 }
 
@@ -44,17 +44,8 @@ export class VarSet extends Command {
   ];
 
   static flags = {
-    description: flags.string({
-      char: 'd',
-      description: 'Description of the variable.',
-    }),
-    tag: flags.string({
-      char: 't',
-      description: 'Tags to set on the variable as TagName:TagValue.',
-      helpValue: 'TagName:TagValue',
-      multiple: true,
-      parse: validateTag,
-    }),
+    description: descriptionFlag,
+    tag: tagFlag,
     withEncryption: flags.string({
       char: 'k',
       description: 'Attempt to encrypt parameter using KMS key name.',

--- a/src/commands/var/set.ts
+++ b/src/commands/var/set.ts
@@ -62,6 +62,5 @@ export class VarSet extends Command {
     const { key, stage, value } = args;
     const environment = await getEnvironment(stage);
     const result = await environment.put(key, value, flags.description);
-    this.log(JSON.stringify(result, undefined, 2));
   }
 }

--- a/src/commands/var/set.ts
+++ b/src/commands/var/set.ts
@@ -6,11 +6,10 @@ import { Stage, stagePositional } from '../../arguments/stage';
 import { Value, valuePositional } from '../../arguments/value';
 import { make as makeExample } from '../../example';
 import { descriptionFlag, WithDescriptionFlag } from '../../flags/description';
-import { tagFlag, WithTagFlag } from '../../flags/tag';
 import { getEnvironment } from '../../projectConfig';
 import { parseTag, Tag, validateTag } from '../../tag';
 
-interface Flags extends WithDescriptionFlag, WithTagFlag {
+interface Flags extends WithDescriptionFlag {
   withEncryption?: string;
 }
 
@@ -45,7 +44,6 @@ export class VarSet extends Command {
 
   static flags = {
     description: descriptionFlag,
-    tag: tagFlag,
     withEncryption: flags.string({
       char: 'k',
       description: 'Attempt to encrypt parameter using KMS key name.',

--- a/src/commands/var/set.ts
+++ b/src/commands/var/set.ts
@@ -9,9 +9,7 @@ import { descriptionFlag, WithDescriptionFlag } from '../../flags/description';
 import { getEnvironment } from '../../projectConfig';
 import { parseTag, Tag, validateTag } from '../../tag';
 
-interface Flags extends WithDescriptionFlag {
-  withEncryption?: string;
-}
+interface Flags extends WithDescriptionFlag {} // tslint:disable-line no-empty-interface
 
 interface Args extends Key, Stage, Value {}
 
@@ -44,11 +42,6 @@ export class VarSet extends Command {
 
   static flags = {
     description: descriptionFlag,
-    withEncryption: flags.string({
-      char: 'k',
-      description: 'Attempt to encrypt parameter using KMS key name.',
-      helpValue: 'KMS Key ARN',
-    }),
   };
 
   static args: Parser.IArg[] = [

--- a/src/commands/var/tag.ts
+++ b/src/commands/var/tag.ts
@@ -1,0 +1,43 @@
+import { Command, flags } from '@oclif/command';
+import { args as Parser } from '@oclif/parser';
+
+import { Key, keyPositional } from '../../arguments/key';
+import { Stage, stagePositional } from '../../arguments/stage';
+import { make as makeExample } from '../../example';
+import { tagFlag, WithTagFlag } from '../../flags/tag';
+import { getEnvironment } from '../../projectConfig';
+import { parseTag } from '../../tag';
+
+interface Flags extends WithTagFlag {} // tslint:disable-line no-empty-interface
+
+interface Args extends Key, Stage {}
+
+export class VarSet extends Command {
+  static description = 'Add tags to a variable. Variable must exist.';
+
+  static examples = [
+    makeExample([
+      `# Set Client tag of FOO variable in test stage.`,
+      `$ ssmenv var:set test FOO --tag=Client:baz`,
+    ]),
+    makeExample([
+      `# Set multiple tags on FOO variable for staging.`,
+      `$ ssmenv var:set staging FOO --tag=Client:baz --tag=Environment:staging`,
+    ]),
+  ];
+
+  static flags = {
+    tag: tagFlag,
+  };
+
+  static args: Parser.IArg[] = [stagePositional, keyPositional];
+
+  async run() {
+    const { args, flags } = this.parse<Flags, Args>(VarSet);
+    const { key, stage } = args;
+    // Despite what the inferred signature of `flags` indicates `tag` can be undefined
+    const tags = (flags.tag || []).map(parseTag);
+    const environment = await getEnvironment(stage);
+    const result = await environment.tag(key, tags);
+  }
+}

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -29,7 +29,7 @@ export type Key = string;
 export type Option<T> = T | undefined;
 /** Type alias for `AWS.SSM.GetParametersByPathResult`. */
 export type Options = Partial<AWS.SSM.GetParametersByPathRequest>;
-/** Type alias for `AWS.SSM.Paramter`. */
+/** Type alias for `AWS.SSM.ParamterHistory`. */
 export type Parameter = AWS.SSM.ParameterHistory;
 /** Type alias for `AWS.SSM.PutParameterRequest`. */
 export type PutRequest = AWS.SSM.PutParameterRequest;

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -288,13 +288,14 @@ export class Environment {
   }
 
   /**
-   * Refresh the values in the configuration cache.
+   * Refresh the values in the configuration cache. This removes old values.
    */
   private async refresh(): Promise<void> {
     const parameters = await this.fetch();
-    parameters
+    const entries = parameters
       .filter(this.hasNameAndType.bind(this))
-      .forEach((param: Parameter) => this.cache.set(param.Name!, param));
+      .map(this.toLruEntry);
+    this.cache.load(entries);
   }
 
   /**
@@ -319,6 +320,20 @@ export class Environment {
         version: param.Version,
       };
     }
+  }
+
+  /**
+   * Convert the given `param` to an object conforming to the `LRUEntry`
+   * interface.
+   * @param param to be converted.
+   * @return an `LRUEntry` with `param` as value.
+   */
+  private toLruEntry(param: Parameter): LRU.LRUEntry<string, Parameter> {
+    return {
+      e: 0,
+      k: param.Name!,
+      v: param,
+    };
   }
 
   /**

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,4 +1,4 @@
-import * as AWS from 'aws-sdk';
+import { AWSError, SSM } from 'aws-sdk';
 import * as LRU from 'lru-cache';
 import { Tag } from './tag';
 
@@ -28,13 +28,13 @@ export type Key = string;
 /** Type alias for a parameterized type that may be undefined. */
 export type Option<T> = T | undefined;
 /** Type alias for `AWS.SSM.GetParametersByPathResult`. */
-export type Options = Partial<AWS.SSM.GetParametersByPathRequest>;
+export type Options = Partial<SSM.GetParametersByPathRequest>;
 /** Type alias for `AWS.SSM.ParamterHistory`. */
-export type Parameter = AWS.SSM.ParameterHistory;
+export type Parameter = SSM.ParameterHistory;
 /** Type alias for `AWS.SSM.PutParameterRequest`. */
-export type PutRequest = AWS.SSM.PutParameterRequest;
+export type PutRequest = SSM.PutParameterRequest;
 /** Type alias for `AWS.SSM.PutParameterResult`. */
-export type PutResult = AWS.SSM.PutParameterResult;
+export type PutResult = SSM.PutParameterResult;
 
 /**
  * Structure of an environment variable.
@@ -116,7 +116,7 @@ export class Environment {
   /** Options to include when requesting parameters. */
   private options: Options;
   /** The `AWS.SSM` instance used to retrieve data. */
-  private ssm: AWS.SSM;
+  private ssm: SSM;
 
   /**
    * Create a `Environment` instance for the given `rootPath` using `ssm` to
@@ -125,7 +125,7 @@ export class Environment {
    * @param {AWS.SSM} ssm to use for retrieving parameters.
    * @param {Options} options for requesting parameters.
    */
-  constructor(fqnPrefix: string, ssm: AWS.SSM, options: Options = {}) {
+  constructor(fqnPrefix: string, ssm: SSM, options: Options = {}) {
     this.validateFqn(fqnPrefix);
     this.cache = LRU({ maxAge: 1000 * 60 * 60 * 24 });
     this.fqnPrefix = fqnPrefix;
@@ -207,7 +207,7 @@ export class Environment {
       Value: value,
     };
     return new Promise<EnvironmentVariable>((resolve, reject) => {
-      this.ssm.putParameter(request, (err: AWS.AWSError, result: PutResult) => {
+      this.ssm.putParameter(request, (err: AWSError, result: PutResult) => {
         if (err) {
           reject(err);
         } else if (result.Version === undefined) {
@@ -242,7 +242,7 @@ export class Environment {
    *    found when using the `fqnPrefix` as a path.
    */
   private fetch(): Promise<Parameter[]> {
-    const options: AWS.SSM.GetParametersByPathRequest = {
+    const options: SSM.GetParametersByPathRequest = {
       ...this.options,
       Path: `${this.fqnPrefix}`,
       Recursive: true,
@@ -250,7 +250,7 @@ export class Environment {
     return new Promise((resolve, reject) => {
       this.ssm.getParametersByPath(
         options,
-        (err: AWS.AWSError, data: AWS.SSM.GetParametersByPathResult) => {
+        (err: AWSError, data: SSM.GetParametersByPathResult) => {
           if (err) {
             reject(err);
           } else {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -50,7 +50,7 @@ export interface EnvironmentVariable {
   /** Tags applied to the parameter. */
   tags?: Tag[];
   /** Value of the parameter. */
-  value?: string;
+  value: string;
   /** Version of the parameter. */
   version?: number;
 }
@@ -331,7 +331,7 @@ export class Environment {
     const path = param.Name || '';
     const data = path.match(this.keyMatcher);
     const key = (data && data[1]) || undefined;
-    if (key === undefined) {
+    if (key === undefined || param.Value === undefined) {
       return undefined;
     } else {
       return {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -21,7 +21,7 @@ const fqnRegex = new RegExp(`^/(${PART.source})(/${PART.source})*?$`);
 const rootPathRegex = new RegExp(`^/((${PART.source})(/${PART.source})*?/)?$`);
 
 /** Type alias for a function converting a string to another, parameterized type. */
-export type Convert<T> = (value: string) => T;
+export type Convert<T> = (value: EnvironmentVariable) => T;
 /** string alias for fully qualified parameter name. */
 export type FQN = string;
 /** string alias for parameter name (not fully qualified). */
@@ -162,7 +162,7 @@ export class Environment {
    * @returns {undefined | string} `undefined` if a value for `key` can not be
    *    found, the found `string` value otherwise.
    */
-  async get(key: Key): Promise<Option<string>> {
+  async get(key: Key): Promise<Option<EnvironmentVariable>> {
     const isReady = await this.isReady;
     const isStale = await this.isStale(key);
     if (!isReady) {
@@ -174,7 +174,9 @@ export class Environment {
     } else {
       const fqn = this.fqn(key);
       const parameter = this.cache.get(fqn);
-      return parameter === undefined ? undefined : parameter.Value;
+      return parameter === undefined
+        ? undefined
+        : this.toEnvironmentVariable(parameter);
     }
   }
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -222,6 +222,31 @@ export class Environment {
   }
 
   /**
+   * Apply `tags` to the variable identified by `key`.
+   * @param key of the parameter to be combined with `fqnPrefix`.
+   * @param tags to add or overwrite.
+   * @returns The `EnvironmentVariable` that was modified including the `tags`.
+   */
+  async tag(key: Key, tags: Tag[] = []): Promise<EnvironmentVariable> {
+    const fqn = this.fqn(key);
+    const request: SSM.AddTagsToResourceRequest = {
+      ResourceId: fqn,
+      ResourceType: 'Parameter',
+      Tags: tags,
+    };
+    const variable = await this.get(key);
+    if (variable === undefined) {
+      throw new Error(`${fqn} is not a known parameter.`);
+    }
+    const result = await this.ssm.addTagsToResource(request);
+    // Put tags on variable
+    return {
+      ...variable,
+      tags,
+    };
+  }
+
+  /**
    * Get all the `EnvironmentVariable` instances we know about.
    * @returns all stored `EnvironmentVariable` instances.
    */

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -216,7 +216,7 @@ export class Environment {
       Version: result.Version,
     };
     this.cache.set(fqn, parameter);
-    return this.toEnvironmentVariable(parameter);
+    return this.toEnvironmentVariable(parameter)!;
   }
 
   /**

--- a/src/environment/AwsSsmProxy.ts
+++ b/src/environment/AwsSsmProxy.ts
@@ -1,0 +1,46 @@
+import { AWSError, SSM } from 'aws-sdk';
+
+/** Type alias for `T` or `undefined`. */
+type Nullable<T> = T | null;
+/** Parameterized type alias for a callback that receives an error or a result. */
+type CB<E extends Error, T> = (err: Nullable<E>, res: T) => void;
+/** Parameterized type alias for function that takes a request and a CB. */
+type Promisable<Req, Res> = (req: Req, callback: CB<AWSError, Res>) => void;
+
+/**
+ * Proxies select methods of `AWS.SSM` using functions that return `Promise`
+ * instances rather than following the callback pattern.
+ */
+export class AwsSsmProxy {
+  addTagsToResource: (
+    request: SSM.AddTagsToResourceRequest
+  ) => Promise<SSM.AddTagsToResourceResult>;
+  getParametersByPath: (
+    request: SSM.GetParametersByPathRequest
+  ) => Promise<SSM.GetParametersByPathResult>;
+  putParameter: (
+    request: SSM.PutParameterRequest
+  ) => Promise<SSM.PutParameterResult>;
+
+  constructor(ssm: SSM) {
+    this.addTagsToResource = this.promisify(ssm.addTagsToResource.bind(ssm));
+    this.getParametersByPath = this.promisify(
+      ssm.getParametersByPath.bind(ssm)
+    );
+    this.putParameter = this.promisify(ssm.putParameter.bind(ssm));
+  }
+
+  private promisify<Req, Res>(fn: Promisable<Req, Res>) {
+    return (request: Req) => {
+      return new Promise<Res>((resolve, reject) => {
+        fn(request, (error: Nullable<AWSError>, response: Res) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(response);
+          }
+        });
+      });
+    };
+  }
+}

--- a/src/flags/description.ts
+++ b/src/flags/description.ts
@@ -1,0 +1,10 @@
+import { Command, flags } from '@oclif/command';
+
+export interface WithDescriptionFlag {
+  description?: string;
+}
+
+export const descriptionFlag = flags.string({
+  char: 'd',
+  description: 'Description of the variable.',
+});

--- a/src/flags/description.ts
+++ b/src/flags/description.ts
@@ -7,4 +7,5 @@ export interface WithDescriptionFlag {
 export const descriptionFlag = flags.string({
   char: 'd',
   description: 'Description of the variable.',
+  name: 'description',
 });

--- a/src/flags/stage.ts
+++ b/src/flags/stage.ts
@@ -15,5 +15,6 @@ export const stageFlag = flags.string({
   description: 'Tags to set on the variable as TagName:TagValue.',
   helpValue: 'stage',
   multiple: true,
+  name: 'stage',
   parse: validateStage,
 });

--- a/src/flags/stage.ts
+++ b/src/flags/stage.ts
@@ -1,0 +1,19 @@
+import { Command, flags } from '@oclif/command';
+import { Environment } from '../environment';
+
+function validateStage(param: string, context?: any) {
+  Environment.validatePathPart('Stage', param);
+  return param;
+}
+
+export interface WithStageFlag {
+  stage: string[];
+}
+
+export const stageFlag = flags.string({
+  char: 's',
+  description: 'Tags to set on the variable as TagName:TagValue.',
+  helpValue: 'stage',
+  multiple: true,
+  parse: validateStage,
+});

--- a/src/flags/tag.ts
+++ b/src/flags/tag.ts
@@ -1,0 +1,14 @@
+import { Command, flags } from '@oclif/command';
+import { parseTag, Tag, validateTag } from '../tag';
+
+export interface WithTagFlag {
+  tag: string[];
+}
+
+export const tagFlag = flags.string({
+  char: 't',
+  description: 'Tags to set on the variable as TagName:TagValue.',
+  helpValue: 'TagName:TagValue',
+  multiple: true,
+  parse: validateTag,
+});

--- a/src/flags/tag.ts
+++ b/src/flags/tag.ts
@@ -10,5 +10,6 @@ export const tagFlag = flags.string({
   description: 'Tags to set on the variable as TagName:TagValue.',
   helpValue: 'TagName:TagValue',
   multiple: true,
+  name: 'tag',
   parse: validateTag,
 });


### PR DESCRIPTION
Fixes #2

When doing `Environment#refresh` completely reload the cached values to
ensure we don't hit a case where the remote parameter is deleted but
there is a non-stale value in cache.

Fix a bug in `env:dotenv` command that printed the full array each time
because creating a closure with `this.log.bind`.

Refactor some flags into separate files for re-usability.

Implement `var:tag` for adding tags to a parameter.

Remove `--tag` flag from `var:set` command.

Remove `--withEncryption` flag from `var:set` command, it wasn't
implemented.

Fixes a typo in the README.
