### PR TITLE
feat(env:list): Create `env:list` command

### DIFF
--- a/src/commands/env/list.ts
+++ b/src/commands/env/list.ts
@@ -1,0 +1,49 @@
+import { Command } from '@oclif/command';
+import { args as Parser } from '@oclif/parser';
+
+import { AwsSsmProxy } from '../../environment/AwsSsmProxy';
+import { make as makeExample } from '../../example';
+import { getDirectEnvironment } from '../../projectConfig';
+
+export class EnvList extends Command {
+  static description = [
+    'List the known stages or environments, ignoring configured `rootPath`.',
+    'A stage or environment is considered any path with a direct child path holding a value.',
+  ].join('\n');
+
+  static examples = [
+    makeExample([
+      `# List out the full paths to all known stages.`,
+      `$ ssmenv env:list`,
+      `/client/project/dev`,
+      `/client/project/production`,
+      `/client/project/test`,
+      `/otherclient/test_project/production`,
+      `/otherproject/dev`,
+    ]),
+  ];
+
+  async run() {
+    const proxy = await getDirectEnvironment();
+    const request = {
+      Path: '/',
+      Recursive: true,
+    };
+    const results = await proxy.getParametersByPath(request);
+    const parameters = results.Parameters || [];
+    parameters
+      .map(param => {
+        const lastSlash = param.Name!.lastIndexOf('/');
+        return param.Name!.slice(0, lastSlash);
+      })
+      .reduce((paths: string[], next: string) => {
+        if (paths.includes(next)) {
+          return paths;
+        } else {
+          return [...paths, next];
+        }
+      }, [])
+      .sort()
+      .forEach(path => this.log(path));
+  }
+}

--- a/src/example/index.ts
+++ b/src/example/index.ts
@@ -14,8 +14,5 @@ function colorizeLine(line: string) {
  * @returns a single string for use in `Command.examples` array.
  */
 export function make(lines: string[]): string {
-  return lines
-    .map(colorizeLine)
-    .join('\n')
-    .concat('\n');
+  return lines.map(colorizeLine).join('\n');
 }

--- a/src/projectConfig.ts
+++ b/src/projectConfig.ts
@@ -7,6 +7,7 @@ import {
   PROJECT_FILE_NAME,
 } from './constants';
 import { Environment, Options } from './environment';
+import { AwsSsmProxy } from './environment/AwsSsmProxy';
 import { Fn, Log } from './log';
 
 /**
@@ -22,6 +23,17 @@ export interface AwsConfig {
  */
 export interface ProjectConfig {
   rootPath: string;
+}
+
+/**
+ * Get direct access to `SSM` using the configuration written at `pathToConfig`.
+ * @param pathToConfig from which the project config will be read.
+ * @return an initialized `AWS.SSM` instance.
+ */
+export async function getDirectEnvironment(pathToConfig?: string) {
+  const awsConfig = await readAwsConfig(pathToConfig);
+  const ssm = getSSM(awsConfig);
+  return new AwsSsmProxy(ssm);
 }
 
 /**


### PR DESCRIPTION
The `env:list` command lists the full path to all know environments. An environment is considered any path with a direct child path holding a value.

Fixes #8