### PR TITLE
feat(var:del): Create `var:del` command

### DIFF
--- a/src/commands/var/del.ts
+++ b/src/commands/var/del.ts
@@ -1,0 +1,36 @@
+import { Command, flags } from '@oclif/command';
+import { args as Parser } from '@oclif/parser';
+
+import { Key, keyPositional } from '../../arguments/key';
+import { Stage, stagePositional } from '../../arguments/stage';
+import { make as makeExample } from '../../example';
+import { getEnvironment } from '../../projectConfig';
+
+interface Flags {} // tslint:disable-line no-empty-interface
+
+interface Args extends Key, Stage {}
+
+export default class VarDel extends Command {
+  static description = 'Delete a variable.';
+
+  static examples = [
+    makeExample([
+      `# Delete variable FOO in test stage.`,
+      `$ ssmenv var:del test FOO`,
+    ]),
+  ];
+
+  static flags = {};
+
+  static args: Parser.IArg[] = [stagePositional, keyPositional];
+
+  async run() {
+    const { args, flags } = this.parse<Flags, Args>(VarDel);
+    const { key, stage } = args;
+    const environment = await getEnvironment(stage);
+    const result = await environment.del(key);
+    if (result === false) {
+      this.exit(1);
+    }
+  }
+}

--- a/src/environment/AwsSsmProxy.ts
+++ b/src/environment/AwsSsmProxy.ts
@@ -15,6 +15,9 @@ export class AwsSsmProxy {
   addTagsToResource: (
     request: SSM.AddTagsToResourceRequest
   ) => Promise<SSM.AddTagsToResourceResult>;
+  deleteParameters: (
+    request: SSM.DeleteParametersRequest
+  ) => Promise<SSM.DeleteParametersResult>;
   getParametersByPath: (
     request: SSM.GetParametersByPathRequest
   ) => Promise<SSM.GetParametersByPathResult>;
@@ -24,6 +27,7 @@ export class AwsSsmProxy {
 
   constructor(ssm: SSM) {
     this.addTagsToResource = this.promisify(ssm.addTagsToResource.bind(ssm));
+    this.deleteParameters = this.promisify(ssm.deleteParameters.bind(ssm));
     this.getParametersByPath = this.promisify(
       ssm.getParametersByPath.bind(ssm)
     );


### PR DESCRIPTION
The `var:del` command delete a variable from the AWS parameter store.