### PR TITLE
Add tests for static methods of Init command

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["plugin:prettier/recommended"]
+  "extends": ["eslint:recommended", "plugin:prettier/recommended"]
 }

--- a/src/command/StageActorCommand.ts
+++ b/src/command/StageActorCommand.ts
@@ -1,5 +1,4 @@
-import { Command, flags } from '@oclif/command';
-import { args as Parser } from '@oclif/parser';
+import { Command, flags } from '@oclif/command'; // tslint:disable-line no-unused-variable
 
 import { pushStage } from '../config/fs';
 import { Option } from '../environment';

--- a/src/commands/env/dotenv.ts
+++ b/src/commands/env/dotenv.ts
@@ -39,7 +39,7 @@ export class EnvDotenv extends Command {
     const { args, flags } = this.parse<Flags, Args>(EnvDotenv);
     const { stage } = args;
     const config = await getEnvironment(stage, {
-      WithDecryption: flags.withDecryption,
+      withDecryption: flags.withDecryption,
     });
     const isReady = await config.isReady;
     if (!isReady) {

--- a/src/commands/env/list.ts
+++ b/src/commands/env/list.ts
@@ -1,8 +1,6 @@
 import { Command } from '@oclif/command';
-import { args as Parser } from '@oclif/parser';
 
 import { getDirectEnvironment } from '../../config/fs';
-import { AwsSsmProxy } from '../../environment/AwsSsmProxy';
 import { make as makeExample } from '../../example';
 
 export class EnvList extends Command {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,4 @@
-import { Command, flags } from '@oclif/command';
+import { Command, flags } from '@oclif/command'; // tslint:disable-line no-unused-variable
 import { args as Parser } from '@oclif/parser';
 import chalk from 'chalk';
 import { prompt, Question } from 'inquirer';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -155,7 +155,9 @@ export class Init extends Command {
     args: Args,
     flags: Flags
   ): Promise<Partial<Answers>> {
-    const currentConfig = await readConfig(DEFAULT_CONFIG_PATH);
+    const currentConfig = await readConfig({
+      pathToConfig: DEFAULT_CONFIG_PATH,
+    });
     return {
       awsAccess: args.awsAccess || currentConfig.accessKeyId,
       awsSecret: args.awsSecret || currentConfig.secretAccessKey,
@@ -252,7 +254,9 @@ export class Init extends Command {
       stages,
     };
 
-    const paths = await writeConfig(config, DEFAULT_CONFIG_PATH);
+    const paths = await writeConfig(config, {
+      pathToConfig: DEFAULT_CONFIG_PATH,
+    });
     const keyword = chalk.keyword('green');
     const [awsPath, projectPath] = paths.map(v => keyword(v));
     const stdout = flags.quiet

--- a/src/commands/var/del.ts
+++ b/src/commands/var/del.ts
@@ -3,8 +3,7 @@ import { args as Parser } from '@oclif/parser';
 
 import { Key, keyPositional } from '../../arguments/key';
 import { StageActorCommand } from '../../command/StageActorCommand';
-import { getEnvironment, pushStage } from '../../config/fs';
-import { Option } from '../../environment';
+import { getEnvironment } from '../../config/fs';
 import { make as makeExample } from '../../example';
 import { stageFlag, WithStageFlag } from '../../flags/stage';
 

--- a/src/commands/var/set.ts
+++ b/src/commands/var/set.ts
@@ -5,7 +5,7 @@ import { Key, keyPositional } from '../../arguments/key';
 import { Value, valuePositional } from '../../arguments/value';
 import { StageActorCommand } from '../../command/StageActorCommand';
 import { getEnvironment } from '../../config/fs';
-import { EnvironmentVariable, Option } from '../../environment';
+import { EnvironmentVariable } from '../../environment';
 import { make as makeExample } from '../../example';
 import { descriptionFlag, WithDescriptionFlag } from '../../flags/description';
 import { stageFlag, WithStageFlag } from '../../flags/stage';

--- a/src/commands/var/tag.ts
+++ b/src/commands/var/tag.ts
@@ -4,7 +4,7 @@ import { args as Parser } from '@oclif/parser';
 import { Key, keyPositional } from '../../arguments/key';
 import { StageActorCommand } from '../../command/StageActorCommand';
 import { getEnvironment } from '../../config/fs';
-import { EnvironmentVariable, Option } from '../../environment';
+import { EnvironmentVariable } from '../../environment';
 import { make as makeExample } from '../../example';
 import { stageFlag, WithStageFlag } from '../../flags/stage';
 import { tagFlag, WithTagFlag } from '../../flags/tag';

--- a/src/config/fs/helpers.ts
+++ b/src/config/fs/helpers.ts
@@ -11,20 +11,28 @@ import { ConfigFile } from './ConfigFile';
 /**
  * Create a new `ConfigFile` for the given configuration path.
  * @param pathToConfig from which the aws config will be read.
+ * @param fileName of the config file within `pathToConfig`
  * @returns a handler for the aws config file.
  */
-export function getAwsConfig(pathToConfig: string = DEFAULT_CONFIG_PATH) {
-  const awsFileName = `${pathToConfig}${pathSeparator}${AWS_FILE_NAME}`;
+export function getAwsConfig(
+  pathToConfig: string = DEFAULT_CONFIG_PATH,
+  fileName: string = AWS_FILE_NAME
+) {
+  const awsFileName = `${pathToConfig}${pathSeparator}${fileName}`;
   return new ConfigFile<AwsConfig>(awsFileName, AwsRequiredProperties);
 }
 
 /**
  * Create a new `ConfigFile` for the given configuration path.
- * @param pathToConfig from which the aws config will be read.
+ * @param pathToConfig from which the project config will be read.
+ * @param fileName of the config file within `pathToConfig`
  * @returns a handler for the project config file.
  */
-export function getProjectConfig(pathToConfig: string = DEFAULT_CONFIG_PATH) {
-  const projectFileName = `${pathToConfig}${pathSeparator}${PROJECT_FILE_NAME}`;
+export function getProjectConfig(
+  pathToConfig: string = DEFAULT_CONFIG_PATH,
+  fileName: string = PROJECT_FILE_NAME
+) {
+  const projectFileName = `${pathToConfig}${pathSeparator}${fileName}`;
   return new ConfigFile<ProjectConfig>(
     projectFileName,
     ProjectRequiredProperties

--- a/src/config/fs/index.ts
+++ b/src/config/fs/index.ts
@@ -93,7 +93,7 @@ export async function pushStage(stage: string, pathToConfig?: string) {
       stages: [...stages, stage],
     };
     const result = await projectFile.write(newConfig);
-    return true;
+    return result === projectFile.fileName;
   }
 }
 

--- a/src/config/fs/index.ts
+++ b/src/config/fs/index.ts
@@ -2,7 +2,7 @@ import { SSM } from 'aws-sdk';
 import { mkdir } from 'fs';
 
 import { DEFAULT_CONFIG_PATH } from '../../constants';
-import { Environment, Options } from '../../environment';
+import { Environment, EnvironmentOptions } from '../../environment';
 import { AwsSsmProxy } from '../../environment/AwsSsmProxy';
 
 import { AwsConfig } from '../AwsConfig';
@@ -50,7 +50,7 @@ export async function getDirectEnvironment(pathToConfig?: string) {
  */
 export async function getEnvironment(
   stage: string,
-  options?: Options,
+  options?: EnvironmentOptions,
   pathToConfig?: string
 ) {
   const awsConfig = await getAwsConfig(pathToConfig).read();

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -120,9 +120,9 @@ export class Environment {
   /**
    * Create a `Environment` instance for the given `rootPath` using `ssm` to
    * retrieve parameter valeus.
-   * @param {string} fqnPrefix path to search.
-   * @param {AWS.SSM} ssm to use for retrieving parameters.
-   * @param {EnvironmentOptions} options for requesting parameters.
+   * @param fqnPrefix path to search.
+   * @param ssm to use for retrieving parameters.
+   * @param options for requesting parameters.
    */
   constructor(fqnPrefix: string, ssm: SSM, options: EnvironmentOptions = {}) {
     this.validateFqn(fqnPrefix);
@@ -163,11 +163,11 @@ export class Environment {
   /**
    * Retrieve a configuration parameter with `key` from the parameter store. The
    * `convert` function transforms the resulting string value into any other type.
-   * @param {string} key to search for.
-   * @param {function} convert to change `string` value into another type.
-   * @param {Type} T the resulting type from `convert`.
-   * @returns {undefined | T} `undefined` if a value for `key` can not be found,
-   *    the result of `convert` on the found value otherwise.
+   * @param key to search for.
+   * @param convert to change `string` value into another type.
+   * @param T the resulting type from `convert`.
+   * @returns `undefined` if a value for `key` can not be found, the result of
+   *    `convert` on the found value otherwise.
    */
   async getAs<T>(key: Key, convert: Convert<T>): Promise<Option<T>> {
     const value = await this.get(key);
@@ -180,9 +180,9 @@ export class Environment {
 
   /**
    * Retrieve a configuration parameter with `key` from the parameter store.
-   * @param {string} key to search for.
-   * @returns {undefined | string} `undefined` if a value for `key` can not be
-   *    found, the found `string` value otherwise.
+   * @param key to search for.
+   * @returns `undefined` if a value for `key` can not be found, the found
+   *    `EnvironmentVariable` value otherwise.
    */
   async get(key: Key): Promise<Option<EnvironmentVariable>> {
     const isReady = await this.isReady;
@@ -279,8 +279,8 @@ export class Environment {
   /**
    * Asynchronously fetches all the parameter values, recursively traversing the
    * parameter tree for the given fqnPrefix.
-   * @returns {Promise<Parameter[]>} the array of `SSM.Parameter` values
-   *    found when using the `fqnPrefix` as a path.
+   * @returns the array of `SSM.Parameter` values found when using the
+   *    `fqnPrefix` as a path.
    */
   private async fetch(): Promise<Parameter[]> {
     const options: SSM.GetParametersByPathRequest = {
@@ -317,7 +317,7 @@ export class Environment {
 
   /**
    * Check that the given `param` has a `Name` defined and a valid `Type`.
-   * @param {AWS.SSM.Parameter} param to test
+   * @param param to test
    * @returns `true` if `Name` exists and `Type` is a convertable type, `false`
    *    otherwise.
    */
@@ -370,9 +370,9 @@ export class Environment {
   /**
    * Convert the given `param` to an object conforming to the `EnvironmentVariable`
    * interface.
-   * @param {AWS.SSM.Parameter} param to be converted.
-   * @return {EnvironmentVariable | undefined} `undefined` if the given `param`
-   *    can not be converted; the `EnvironmentVariable` otherwise.
+   * @param param to be converted.
+   * @return `undefined` if the given `param` can not be converted; the
+   *    `EnvironmentVariable` otherwise.
    */
   private toEnvironmentVariable(param: Parameter): Option<EnvironmentVariable> {
     const path = param.Name || '';

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -22,14 +22,8 @@ export type FQN = string;
 export type Key = string;
 /** Type alias for a parameterized type that may be undefined. */
 export type Option<T> = T | undefined;
-/** Type alias for `AWS.SSM.GetParametersByPathResult`. */
-export type Options = Partial<SSM.GetParametersByPathRequest>;
 /** Type alias for `AWS.SSM.ParamterHistory`. */
 export type Parameter = SSM.ParameterHistory;
-/** Type alias for `AWS.SSM.PutParameterRequest`. */
-export type PutRequest = SSM.PutParameterRequest;
-/** Type alias for `AWS.SSM.PutParameterResult`. */
-export type PutResult = SSM.PutParameterResult;
 
 /**
  * Options available when creating an `Environment` instance.
@@ -230,7 +224,7 @@ export class Environment {
    */
   async put(key: Key, value: string, description?: string) {
     const fqn = this.fqn(key);
-    const request: PutRequest = {
+    const request: SSM.PutParameterRequest = {
       Description: description,
       Name: fqn,
       Overwrite: true,

--- a/src/flags/description.ts
+++ b/src/flags/description.ts
@@ -1,4 +1,4 @@
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 
 export interface WithDescriptionFlag {
   description?: string;

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -1,0 +1,65 @@
+/// <reference types="jest" />
+import { IConfig } from '@oclif/config';
+import { Init } from '../../src/commands/init';
+
+describe(Init.isValidPathPart, () => {
+  it('returns error if key is empty', () => {
+    const err = Init.isValidPathPart('');
+    expect(err).toMatch('Stage is not valid,');
+  });
+  it('returns error if key contains .', () => {
+    const err = Init.isValidPathPart('key.');
+    expect(err).toMatch('Stage is not valid,');
+  });
+  it('returns error if key contains /', () => {
+    const err = Init.isValidPathPart('key/');
+    expect(err).toMatch('Stage is not valid,');
+  });
+  it('returns error if key contains \\', () => {
+    const err = Init.isValidPathPart('key\\');
+    expect(err).toMatch('Stage is not valid,');
+  });
+  it('returns true for valid path part', () => {
+    expect(Init.isValidPathPart('valId_kEy-Here1')).toBe(true);
+  });
+});
+
+describe(Init.isValidPathParts, () => {
+  it('returns error if any key is empty', () => {
+    const err = Init.isValidPathParts('valId_kEy-Here1,');
+    expect(err).toMatch('Stage is not valid,');
+  });
+  it('returns error if any key contains .', () => {
+    const err = Init.isValidPathParts('valId_kEy-Here1,key.');
+    expect(err).toMatch('Stage is not valid,');
+  });
+  it('returns error if any key contains /', () => {
+    const err = Init.isValidPathParts('valId_kEy-Here1,key/');
+    expect(err).toMatch('Stage is not valid,');
+  });
+  it('returns error if any key contains \\', () => {
+    const err = Init.isValidPathParts('valId_kEy-Here1,key\\');
+    expect(err).toMatch('Stage is not valid,');
+  });
+  it('returns true for valid path part', () => {
+    expect(Init.isValidPathParts('valId_kEy-Here1,valId_kEy-Here1')).toBe(true);
+  });
+});
+
+describe(Init.isValidRootPath, () => {
+  it('returns true if path is /', () => {
+    expect(Init.isValidRootPath('/')).toBe(true);
+  });
+  it('returns true if path has valid parts', () => {
+    expect(Init.isValidRootPath('/valId_kEy-Here1/')).toBe(true);
+  });
+  it('returns error if input does not start with /', () => {
+    expect(Init.isValidRootPath('bin/')).toMatch("start with '/'");
+  });
+  it('returns error if input does not end with /', () => {
+    expect(Init.isValidRootPath('/bin')).toMatch("end with '/'");
+  });
+  it('returns error if input does not have intermediate keys', () => {
+    expect(Init.isValidRootPath('//')).toMatch('not have empty intermediate');
+  });
+});

--- a/test/config/fs/index.test.ts
+++ b/test/config/fs/index.test.ts
@@ -23,33 +23,36 @@ jest.mock('aws-sdk', () => {
   };
 });
 
+const validConfigPath = { pathToConfig: 'fixtures' };
+const invalidConfigPath = { pathToConfig: 'nofixtures' };
+
 describe(getDirectEnvironment, () => {
   it('gets an instance with valid path', async () => {
-    const ssm = await getDirectEnvironment('fixtures');
+    const ssm = await getDirectEnvironment(validConfigPath);
     expect(ssm).toBeInstanceOf(AwsSsmProxy);
   });
   it('throws an error with invalid path', async () => {
     expect.assertions(1);
-    await expect(getDirectEnvironment('nofixtures')).rejects.toBeDefined();
+    await expect(getDirectEnvironment(invalidConfigPath)).rejects.toBeDefined();
   });
 });
 
 describe(getEnvironment, () => {
   it('gets an instance with a valid path', async () => {
-    const env = await getEnvironment('stage', undefined, 'fixtures');
+    const env = await getEnvironment('stage', validConfigPath);
     expect(env).toBeInstanceOf(Environment);
   });
   it('throws an error with invalid path', async () => {
     expect.assertions(1);
     await expect(
-      getEnvironment('stage', undefined, 'nofixtures')
+      getEnvironment('stage', invalidConfigPath)
     ).rejects.toBeDefined();
   });
 });
 
 describe(readConfig, () => {
   it('reads full config with valid path', async () => {
-    const config = await readConfig('fixtures');
+    const config = await readConfig(validConfigPath);
     expect.assertions(
       AwsRequiredProperties.length + ProjectRequiredProperties.length
     );
@@ -62,6 +65,6 @@ describe(readConfig, () => {
   });
   it('throws an error with invalid path', async () => {
     expect.assertions(1);
-    await expect(readConfig('nofixtures')).rejects.toBeDefined();
+    await expect(readConfig(invalidConfigPath)).rejects.toBeDefined();
   });
 });

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,8 @@
   "extends": ["tslint:latest", "tslint-config-prettier"],
   "rules": {
     "member-access": [true, "no-public"],
-    "interface-name": [false],
-    "no-shadowed-variable": [false]
+    "interface-name": false,
+    "no-shadowed-variable": false,
+    "no-unused-variable": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,9 @@
 {
   "extends": ["tslint:latest", "tslint-config-prettier"],
   "rules": {
-    "member-access": [true, "no-public"],
+    "member-access": {
+      "options": ["no-public"]
+    },
     "interface-name": false,
     "no-shadowed-variable": false,
     "no-unused-variable": true


### PR DESCRIPTION
Change linting configuration to error on unused variables. Create `ConfigOptions` interface which is passed to methods which previously wanted `pathToConfig`.