### PR TITLE
Remove aws-sdk from direct ssmenv-cli dependencies

### DIFF
--- a/packages/ssmenv-cli/CHANGELOG.md
+++ b/packages/ssmenv-cli/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 [kac]: http://keepachangelog.com/en/1.0.0/
 [semver]: http://semver.org/spec/v2.0.0.html
 
+# _NEXT_
+
+## Changed
+
+* The `env:list` command now calls out to the `Environment` class rather than
+  getting an instance to access the AWS API directly.
+
 # v0.6.0 (2018-04-24)
 
 ## Added

--- a/packages/ssmenv-cli/CHANGELOG.md
+++ b/packages/ssmenv-cli/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * The `env:list` command now calls out to the `Environment` class rather than
   getting an instance to access the AWS API directly.
 
+## Removed
+
+* Drop the `getDirectEnvironment` method. This function was only exported
+  internally.
+
 # v0.6.0 (2018-04-24)
 
 ## Added

--- a/packages/ssmenv-cli/package.json
+++ b/packages/ssmenv-cli/package.json
@@ -18,7 +18,6 @@
     "@oclif/config": "^1.3.62",
     "@oclif/parser": "^3.2.11",
     "@oclif/plugin-help": "^1.2.2",
-    "aws-sdk": "^2.222.1",
     "chalk": "^2.3.2",
     "inquirer": "^5.2.0",
     "ssmenv": "0.6.0"

--- a/packages/ssmenv-cli/src/commands/env/list.ts
+++ b/packages/ssmenv-cli/src/commands/env/list.ts
@@ -1,6 +1,7 @@
 import { Command } from '@oclif/command';
+import { Environment } from 'ssmenv';
 
-import { getDirectEnvironment } from '../../config/fs';
+import { getAwsConfig } from '../../config/fs/helpers';
 import { make as makeExample } from '../../example';
 
 export class EnvList extends Command {
@@ -22,26 +23,15 @@ export class EnvList extends Command {
   ];
 
   async run() {
-    const proxy = await getDirectEnvironment();
-    const request = {
-      Path: '/',
-      Recursive: true,
+    const configFile = await getAwsConfig();
+    const awsConfig = await configFile.read();
+    const instanceConfig = {
+      accessKeyId: awsConfig.accessKeyId,
+      apiVersion: '2014-11-06',
+      region: 'us-east-1',
+      secretAccessKey: awsConfig.secretAccessKey,
     };
-    const results = await proxy.getParametersByPath(request);
-    const parameters = results.Parameters || [];
-    parameters
-      .map(param => {
-        const lastSlash = param.Name!.lastIndexOf('/');
-        return param.Name!.slice(0, lastSlash);
-      })
-      .reduce((paths: string[], next: string) => {
-        if (paths.includes(next)) {
-          return paths;
-        } else {
-          return [...paths, next];
-        }
-      }, [])
-      .sort()
-      .forEach(path => this.log(path));
+    const results: string[] = await Environment.listAll(instanceConfig);
+    results.forEach(path => this.log(path));
   }
 }

--- a/packages/ssmenv-cli/src/config/fs/index.ts
+++ b/packages/ssmenv-cli/src/config/fs/index.ts
@@ -1,6 +1,11 @@
 import { SSM } from 'aws-sdk';
 import { mkdir } from 'fs';
-import { AwsSsmProxy, Environment, EnvironmentOptions } from 'ssmenv';
+import {
+  AwsSsmProxy,
+  Configuration,
+  Environment,
+  EnvironmentOptions,
+} from 'ssmenv';
 
 import { DEFAULT_CONFIG_PATH } from '../../constants';
 
@@ -80,13 +85,13 @@ export async function getEnvironment(
  * @param config with API info.
  * @returns the initialized `AWS.SSM` instance ready to make requests.
  */
-function getSSM(config: AwsConfig): SSM {
-  return new SSM({
+function getSSM(config: AwsConfig): Configuration {
+  return {
     accessKeyId: config.accessKeyId,
     apiVersion: '2014-11-06',
     region: 'us-east-1',
     secretAccessKey: config.secretAccessKey,
-  });
+  };
 }
 
 /**

--- a/packages/ssmenv-cli/src/config/fs/index.ts
+++ b/packages/ssmenv-cli/src/config/fs/index.ts
@@ -1,11 +1,5 @@
-import { SSM } from 'aws-sdk';
 import { mkdir } from 'fs';
-import {
-  AwsSsmProxy,
-  Configuration,
-  Environment,
-  EnvironmentOptions,
-} from 'ssmenv';
+import { Configuration, Environment, EnvironmentOptions } from 'ssmenv';
 
 import { DEFAULT_CONFIG_PATH } from '../../constants';
 
@@ -43,19 +37,6 @@ function ensureConfigDirectory(pathToConfig: string) {
       }
     });
   });
-}
-
-/**
- * Get direct access to `SSM` using the configuration written at `pathToConfig`.
- * @param options indicating filesystem paths where the configuration will be
- *    read.
- * @return an initialized `AWS.SSM` instance.
- */
-export async function getDirectEnvironment(options: ConfigOptions = {}) {
-  const { awsConfigFileName, pathToConfig } = options;
-  const awsConfig = await getAwsConfig(pathToConfig, awsConfigFileName).read();
-  const ssm = getSSM(awsConfig);
-  return new AwsSsmProxy(ssm);
 }
 
 /**

--- a/packages/ssmenv-cli/src/tag.ts
+++ b/packages/ssmenv-cli/src/tag.ts
@@ -1,8 +1,4 @@
-/* tslint:disable no-empty-interface */
-import * as AWS from 'aws-sdk';
-
-/** Alias for `AWS.SSM.Tag`. */
-export interface Tag extends AWS.SSM.Tag {}
+import { Tag } from 'ssmenv';
 
 /**
  * Validate `param` can be parsed into a `Tag`.

--- a/packages/ssmenv-cli/test/config/fs/index.test.ts
+++ b/packages/ssmenv-cli/test/config/fs/index.test.ts
@@ -3,11 +3,7 @@
 import { resolve } from 'path';
 import { AwsSsmProxy, Environment } from 'ssmenv';
 import { AwsRequiredProperties } from '../../../src/config/AwsConfig';
-import {
-  getDirectEnvironment,
-  getEnvironment,
-  readConfig,
-} from '../../../src/config/fs/index';
+import { getEnvironment, readConfig } from '../../../src/config/fs/index';
 import { ProjectRequiredProperties } from '../../../src/config/ProjectConfig';
 
 jest.mock('aws-sdk', () => {
@@ -27,17 +23,6 @@ const PROJECT_ROOT = resolve(__dirname, '../../../');
 
 const validConfigPath = { pathToConfig: resolve(PROJECT_ROOT, 'fixtures') };
 const invalidConfigPath = { pathToConfig: resolve(PROJECT_ROOT, 'nofixtures') };
-
-describe(getDirectEnvironment, () => {
-  it('gets an instance with valid path', async () => {
-    const ssm = await getDirectEnvironment(validConfigPath);
-    expect(ssm).toBeInstanceOf(AwsSsmProxy);
-  });
-  it('throws an error with invalid path', async () => {
-    expect.assertions(1);
-    await expect(getDirectEnvironment(invalidConfigPath)).rejects.toBeDefined();
-  });
-});
 
 describe(getEnvironment, () => {
   it('gets an instance with a valid path', async () => {

--- a/packages/ssmenv/CHANGELOG.md
+++ b/packages/ssmenv/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 [kac]: http://keepachangelog.com/en/1.0.0/
 [semver]: http://semver.org/spec/v2.0.0.html
 
+# _NEXT_
+
+## Added
+
+* Export the `Configuration` type which provides is used to enable access to
+  the API of the AWS SSM Parameter Store.
+
 # v0.6.0 (2018-04-24)
 
 ## Added

--- a/packages/ssmenv/CHANGELOG.md
+++ b/packages/ssmenv/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * Export the `Configuration` type which provides is used to enable access to
   the API of the AWS SSM Parameter Store.
+* Export the `Tag` type which provides information about AWS tags attached to a
+  resource.
 * Add the static `Environment.listAll` method to retrieve an array of all the
   path names which could be used as Environments (because they have leaf
   nodes).

--- a/packages/ssmenv/CHANGELOG.md
+++ b/packages/ssmenv/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * Export the `Configuration` type which provides is used to enable access to
   the API of the AWS SSM Parameter Store.
+* Add the static `Environment.listAll` method to retrieve an array of all the
+  path names which could be used as Environments (because they have leaf
+  nodes).
 
 # v0.6.0 (2018-04-24)
 

--- a/packages/ssmenv/src/index.ts
+++ b/packages/ssmenv/src/index.ts
@@ -3,3 +3,4 @@ export { Configuration } from './AwsSsmTypes';
 export { Environment } from './Environment';
 export { EnvironmentOptions } from './EnvironmentOptions';
 export { EnvironmentVariable } from './EnvironmentVariable';
+export { Tag } from './Tag';

--- a/packages/ssmenv/src/index.ts
+++ b/packages/ssmenv/src/index.ts
@@ -1,4 +1,5 @@
 export { AwsSsmProxy } from './AwsSsmProxy';
+export { Configuration } from './AwsSsmTypes';
 export { Environment } from './Environment';
 export { EnvironmentOptions } from './EnvironmentOptions';
 export { EnvironmentVariable } from './EnvironmentVariable';


### PR DESCRIPTION
Let the `ssmenv` library wrap all the interactions with the AWS API. This provides a more logical separation of concerns between the two packages.