### PR TITLE
Fetch all parameters

### DIFF
--- a/packages/ssmenv/CHANGELOG.md
+++ b/packages/ssmenv/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 [kac]: http://keepachangelog.com/en/1.0.0/
 [semver]: http://semver.org/spec/v2.0.0.html
 
+# _NEXT_
+
+## Fixed
+
+* Fixes an issue where only the first ten (10) parameters were retrieved by
+  `Environment`.
+
 # v0.6.2 (2018-04-23)
 
 Republish v0.6.1 but automatically.

--- a/packages/ssmenv/src/Environment.ts
+++ b/packages/ssmenv/src/Environment.ts
@@ -32,13 +32,7 @@ export class Environment {
    *    at least one child parameter.
    */
   static async listAll(ssm: SSM | SSMConfiguration) {
-    const instance = new AwsSsmProxy(ssm);
-    const request = {
-      Path: '/',
-      Recursive: true,
-    };
-    const results = await instance.getParametersByPath(request);
-    const parameters = results.Parameters || [];
+    const parameters = await Environment.fetch('/', ssm);
     return parameters
       .map(param => {
         const lastSlash = param.Name!.lastIndexOf('/');
@@ -318,13 +312,7 @@ export class Environment {
    *    `fqnPrefix` as a path.
    */
   private async fetch(): Promise<Parameter[]> {
-    const options: SSM.GetParametersByPathRequest = {
-      Path: `${this.fqnPrefix}`,
-      Recursive: true,
-      WithDecryption: this.options.withDecryption,
-    };
-    const result = await this.ssm.getParametersByPath(options);
-    return result.Parameters || [];
+    return Environment.fetch(this.fqnPrefix, this.ssm, this.options);
   }
 
   /**


### PR DESCRIPTION
Use recursion to retrieve all the environment variables declared for a given path. The `Environment.fetch` method is a wrapper around `SSM#getParametersByPath` that performs requests while the response contains a `NextToken`.